### PR TITLE
I wanted to create this as an issue but was unable

### DIFF
--- a/ewayrecurring.php
+++ b/ewayrecurring.php
@@ -109,7 +109,7 @@ class com_chrischinchilla_ewayrecurring extends CRM_Core_Payment
         //----------------------------------------------------------------------------------------------------
 
         // Was the recurring payment check box checked?
-        if ($params['is_recur'] == 1) {
+        if (isset($params['is_recur']) && $params['is_recur'] == 1) {
 
             // eWAY Gateway URL
             $gateway_URL = $this->_paymentProcessor['url_recur'];
@@ -230,6 +230,11 @@ class com_chrischinchilla_ewayrecurring extends CRM_Core_Payment
                 return self::errorExit( 9002, "Error: Unable to create eWAY Response object.");
             }
 
+            //-------------------------------------------------------------
+            // Prepare some composite data from _paymentProcessor fields
+            //-------------------------------------------------------------
+            $fullAddress = $params['street_address'] . ", " . $params['city'] . ", " . $params['state_province'] . ".";
+
             //----------------------------------------------------------------------------------------------------
             // We use CiviCRM's param's 'invoiceID' as the unique transaction token to feed to eWAY
             // Trouble is that eWAY only accepts 16 chars for the token, while CiviCRM's invoiceID is an 32.
@@ -272,7 +277,6 @@ class com_chrischinchilla_ewayrecurring extends CRM_Core_Payment
             $eWAYRequest->EwayOption3($txtOptions);  //  255 Chars - ewayOption3
 
             $eWAYRequest->CustomerIPAddress ($params['ip_address']);
-            $eWAYRequest->CustomerBillingCountry($params['country']);
 
             // Allow further manipulation of the arguments via custom hooks ..
             CRM_Utils_Hook::alterPaymentProcessorParams( $this, $params, $eWAYRequest );


### PR DESCRIPTION
Chris, I was hoping to create this as an issue, but was unable. Is it OK to be given that permission? Thx.

This change prevents 3 notices from being generated by unset $params values:
1. 'is_recur' was not being tested before being used
2. the code for setting 'fullAddress' had been omitted when the in-core eWAY processor was copied
3. the setting of 'country' was removed because a) it's not expected by eWAY as part of the request and b) it's not in the 2-letter format eWAY expects (I think CiviCRM supplies 'country' as 3-letter ISO codes).

The issue I wanted to raise is with respect to 3.b. I don't think any current action is needed, but I just want to put it 'out there' so folks knew about it. The issue is

> If we want to pass country codes to eWAY, they need to be converted from 3-letter to 2-letter codes. 
