### PR TITLE
Increment version and remove ill-considered spam-error handling

### DIFF
--- a/CRM/Core/Payment/Ewayrecurring.php
+++ b/CRM/Core/Payment/Ewayrecurring.php
@@ -372,63 +372,6 @@ class CRM_Core_Payment_Ewayrecurring extends CRM_Core_Payment {
   }
 
   /**
-   * Send an alert email.
-   *
-   * @param $p_eWAY_tran_num
-   * @param $p_trxn_out
-   * @param $p_trxn_back
-   * @param $p_request
-   * @param $p_response
-   */
-  public function send_alert_email($p_eWAY_tran_num, $p_trxn_out, $p_trxn_back, $p_request, $p_response) {
-    // Initialization call is required to use CiviCRM APIs.
-    civicrm_initialize(TRUE);
-
-    list($fromName, $fromEmail) = CRM_Core_BAO_Domain::getNameAndEmail();
-    $from      = "$fromName <$fromEmail>";
-
-    $toName    = 'Support at eWAY';
-    $toEmail   = 'Support@eWAY.com.au';
-
-    $subject   = "ALERT: Unique Trxn Number Failure : eWAY Transaction # = [" . $p_eWAY_tran_num . "]";
-
-    $message   = "
-TRXN sent out with request   = '$p_trxn_out'.
-TRXN sent back with response = '$p_trxn_back'.
-
-This is a ['$this->_mode'] transaction.
-
-
-Request XML =
----------------------------------------------------------------------------
-$p_request
----------------------------------------------------------------------------
-
-
-Response XML =
----------------------------------------------------------------------------
-$p_response
----------------------------------------------------------------------------
-
-
-Regards
-
-The CiviCRM eWAY Payment Processor Module
-";
-
-    $params                = array();
-
-    $params['groupName'] = 'eWay Email Sender';
-    $params['from'] = $from;
-    $params['toName'] = $toName;
-    $params['toEmail'] = $toEmail;
-    $params['subject'] = $subject;
-    $params['text'] = $message;
-
-    CRM_Utils_Mail::send($params);
-  }
-
-  /**
    * Pass xml to eWay gateway and return response if the call succeeds.
    *
    * @param $requestXML
@@ -806,7 +749,6 @@ The CiviCRM eWAY Payment Processor Module
 
     if ($eWayTrxnReference_IN != $eWayTrxnReference_OUT) {
       // return self::errorExit( 9009, "Error: Unique Trxn code was not returned by eWAY Gateway. This is extremely unusual! Please contact the administrator of this site immediately with details of this transaction.");
-      self::send_alert_email($eWAYResponse->TransactionNumber(), $eWayTrxnReference_OUT, $eWayTrxnReference_IN, $requestXML, $responseData);
     }
 
     $status = ($eWAYResponse->BeagleScore()) ? ($eWAYResponse->Status() . ': ' . $eWAYResponse->BeagleScore()) : $eWAYResponse->Status();

--- a/info.xml
+++ b/info.xml
@@ -15,12 +15,13 @@
     <email>noreply@civicrm.org</email>
   </maintainer>
   <releaseDate>2013-08-31</releaseDate>
-  <version>1.0</version>
+  <version>1.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.4</ver>
     <ver>4.5</ver>
     <ver>4.6</ver>
+    <ver>4.7</ver>
   </compatibility>
   <comments></comments>
     <civix>


### PR DESCRIPTION
The error handling that sends an email to eway is not a sensible method and is not sanitised.

I have not reviewed an alternative - simply removed the agreed bad method