### PR TITLE
Fix invalid test of returned eWAY TrxnReference

### DIFF
--- a/CRM/Core/Payment/Ewayrecurring.php
+++ b/CRM/Core/Payment/Ewayrecurring.php
@@ -757,7 +757,7 @@ class CRM_Core_Payment_Ewayrecurring extends CRM_Core_Payment {
     // There is an error message commented out here but my preferred response to this unlikely
     // possibility is to email 'support@eWAY.com.au'
     //-----------------------------------------------------------------------------------------------------
-    $eWayTrxnReference_OUT = $params['invoiceID'];
+    $eWayTrxnReference_OUT = $eWAYRequest->GetTransactionNumber();
     $eWayTrxnReference_IN = $eWAYResponse->InvoiceReference();
 
     if ($eWayTrxnReference_IN != $eWayTrxnReference_OUT) {


### PR DESCRIPTION
The test I have fixed used to fail every time for me. Since line 764 has been commented out this no longer has any impact, bu I thought it best to fix the comparison lest it be resurrected.