### PR TITLE
Fix compatiblity issue with Civi 5.22: don't call the Civi API with a…

### DIFF
--- a/CRM/Core/Payment/Ewayrecurring.php
+++ b/CRM/Core/Payment/Ewayrecurring.php
@@ -379,6 +379,9 @@ class CRM_Core_Payment_Ewayrecurring extends CRM_Core_Payment {
     if ($entity == 'recur') {
       $entity = 'contribution_recur';
     }
+    if (empty($entity)) {
+      return 0;
+    }
     try {
       return civicrm_api3($entity, 'getvalue', array('id' => $entityID, 'return' => 'contact_id'));
     }

--- a/info.xml
+++ b/info.xml
@@ -14,14 +14,15 @@
     <author>Melbourne CiviCRM</author>
     <email>noreply@civicrm.org</email>
   </maintainer>
-  <releaseDate>2016-01-18</releaseDate>
-  <version>1.2</version>
+  <releaseDate>2020-02-19</releaseDate>
+  <version>1.2.1</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.4</ver>
     <ver>4.5</ver>
     <ver>4.6</ver>
     <ver>4.7</ver>
+    <ver>5.22</ver>
   </compatibility>
   <comments></comments>
     <civix>


### PR DESCRIPTION
… non-existent entity

This issue causes all donation pages in Civi 5.22 using this processor to fail.  It's a critical fix.